### PR TITLE
Add box-sizing to the "mapboxgl-ctrl-scale"-class

### DIFF
--- a/dist/mapbox-gl.css
+++ b/dist/mapbox-gl.css
@@ -223,6 +223,7 @@ a.mapboxgl-ctrl-logo {
     border-color: #333;
     padding: 0 5px;
     color: #333;
+    box-sizing: border-box;
 }
 
 .mapboxgl-popup {


### PR DESCRIPTION
This will fix the problem with the scalebar-controller being too wide

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
